### PR TITLE
Add last chance mechanism for decorating log datum before logging occurs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-log",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A simple logging wrapper.",
   "main": "source/Fable-Log.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "gulp-sourcemaps": "^2.6.5",
     "gulp-terser": "^1.1.7",
     "gulp-util": "^3.0.8",
-    "mocha": "6.1.4",
+    "mocha": "6.2.3",
     "nyc": "^14.1.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"

--- a/source/Fable-Log.js
+++ b/source/Fable-Log.js
@@ -40,6 +40,8 @@ class FableLog
 		this.logStreamsError = [];
 		this.logStreamsFatal = [];
 
+		this.datumDecorator = (pDatum) => pDatum;
+
 		this.uuid = (typeof(tmpSettings.Product) === 'string') ? tmpSettings.Product : 'Default';
 	}
 
@@ -76,51 +78,69 @@ class FableLog
 		return true;
 	}
 
+	setDatumDecorator(fDatumDecorator)
+	{
+		if (typeof(fDatumDecorator) === 'function')
+		{
+			this.datumDecorator = fDatumDecorator;
+		}
+		else
+		{
+			this.datumDecorator = (pDatum) => pDatum;
+		}
+	}
+
 	trace(pMessage, pDatum)
 	{
+		const tmpDecoratedDatum = this.datumDecorator(pDatum);
 		for (let i = 0; i < this.logStreamsTrace.length; i++)
 		{
-			this.logStreamsTrace[i].trace(pMessage, pDatum);
+			this.logStreamsTrace[i].trace(pMessage, tmpDecoratedDatum);
 		}
 	}
 
 	debug(pMessage, pDatum)
 	{
+		const tmpDecoratedDatum = this.datumDecorator(pDatum);
 		for (let i = 0; i < this.logStreamsDebug.length; i++)
 		{
-			this.logStreamsDebug[i].debug(pMessage, pDatum);
+			this.logStreamsDebug[i].debug(pMessage, tmpDecoratedDatum);
 		}
 	}
 
 	info(pMessage, pDatum)
 	{
+		const tmpDecoratedDatum = this.datumDecorator(pDatum);
 		for (let i = 0; i < this.logStreamsInfo.length; i++)
 		{
-			this.logStreamsInfo[i].info(pMessage, pDatum);
+			this.logStreamsInfo[i].info(pMessage, tmpDecoratedDatum);
 		}
 	}
 
 	warn(pMessage, pDatum)
 	{
+		const tmpDecoratedDatum = this.datumDecorator(pDatum);
 		for (let i = 0; i < this.logStreamsWarn.length; i++)
 		{
-			this.logStreamsWarn[i].warn(pMessage, pDatum);
+			this.logStreamsWarn[i].warn(pMessage, tmpDecoratedDatum);
 		}
 	}
 
 	error(pMessage, pDatum)
 	{
+		const tmpDecoratedDatum = this.datumDecorator(pDatum);
 		for (let i = 0; i < this.logStreamsError.length; i++)
 		{
-			this.logStreamsError[i].error(pMessage, pDatum);
+			this.logStreamsError[i].error(pMessage, tmpDecoratedDatum);
 		}
 	}
 
 	fatal(pMessage, pDatum)
 	{
+		const tmpDecoratedDatum = this.datumDecorator(pDatum);
 		for (let i = 0; i < this.logStreamsFatal.length; i++)
 		{
-			this.logStreamsFatal[i].fatal(pMessage, pDatum);
+			this.logStreamsFatal[i].fatal(pMessage, tmpDecoratedDatum);
 		}
 	}
 
@@ -137,7 +157,7 @@ class FableLog
 			}
 			else
 			{
-				this.addLogger(new this._Providers[tmpStreamDefinition.loggertype](tmpStreamDefinition, this), tmpStreamDefinition.level);				
+				this.addLogger(new this._Providers[tmpStreamDefinition.loggertype](tmpStreamDefinition, this), tmpStreamDefinition.level);
 			}
 		}
 
@@ -155,7 +175,7 @@ class FableLog
 		this.info(`${tmpMessage} ${tmpTime} (epoch ${+tmpTime})`, pDatum);
 	}
 
-	// Get a timestamp 
+	// Get a timestamp
 	getTimeStamp()
 	{
 		return +new Date();

--- a/test/Fable-Log_tests.js
+++ b/test/Fable-Log_tests.js
@@ -152,6 +152,37 @@ suite
 				);
 				test
 				(
+					'leveraging a custom datum decorator',
+					function()
+					{
+						var tmpFableLog = require('../source/Fable-Log.js').new({ LogStreams: [{ Context:'Testing Purposes' }]});
+						tmpFableLog.setDatumDecorator((pDatum) =>
+						{
+							const decoratedDatum =
+							{
+								Size: 'large',
+								Time: new Date().toISOString(),
+							};
+							if (pDatum && pDatum.LuggageCombination > 0)
+							{
+								decoratedDatum.Insecure = true;
+							}
+							Object.assign(decoratedDatum, pDatum);
+							return decoratedDatum;
+						});
+						tmpFableLog.initialize();
+
+						const tmpDatum = { LuggageCombination: 12345 };
+						tmpFableLog.trace('Test of Trace', tmpDatum);
+						tmpFableLog.debug('Test of Debug', tmpDatum);
+						tmpFableLog.info('Test of Info', tmpDatum);
+						tmpFableLog.warn('Test of Warning', tmpDatum);
+						tmpFableLog.error('Test of Error', tmpDatum);
+						tmpFableLog.fatal('Test of Fatal', tmpDatum);
+					}
+				);
+				test
+				(
 					'writing to all log streams with a context',
 					function()
 					{


### PR DESCRIPTION
This is useful, for example, for attaching consistent logging metadata to each log line. For example, the request URL, UUID, session data, etc. Incorporating this into the core logger has two main benefits:
* No log wrapper is needed to achieve this outcome.
* All existing code gets the benefits of this mechanism without any code changes.